### PR TITLE
feat: Flycheck lint and type checking customisations for python

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,6 @@ On-the-fly syntax checking for GNU Emacs 24.
 ### flycheck-clj-kondo
 This package integrates clj-kondo with Emacs via flycheck. Make sure you also have clj-kondo installed globally on your machine according to the official install instructions.
 
-### flymake-ruff
-Flymake plugin to run a linter for python buffers using ruff.
-
 ### gptel
 GPTel is a simple Large Language Model chat client for Emacs, with support for multiple models/backends.
 

--- a/customizations/setup-python-flycheck.el
+++ b/customizations/setup-python-flycheck.el
@@ -1,0 +1,91 @@
+;;; setup-python-flycheck.el --- Python
+
+;;; Commentary:
+;;  Flycheck customizations for Python development
+
+
+;;; Code:
+
+(defun in-path? (path exe-path)
+  "Return non-nil if the executable EXE-PATH is in PATH."
+  (and (string-match-p path (file-truename exe-path)) t))
+
+(defun local? (exe)
+  "Return non-nil if the executable EXE is a local .venv install."
+  (and (in-path? (auto-virtualenv-locate-project-root) exe) t))
+
+(defun find-exe (name)
+  "Return non-nil if executable NAME exists in current `exec-path`."
+  (executable-find name))
+
+(defun has-exe? (name)
+  "Return non-nil if executable NAME exist and isn't a global install."
+  (and (when-let ((p (find-exe name)))
+         (local? p))
+       t))
+
+(defun has-mypy? ()
+  "Check if mypy exists in the current environment."
+   (has-exe? "mypy"))
+
+(defun has-flake8? ()
+    "Check if flake8 exists in the current environment."
+    (has-exe? "flake8"))
+
+(defun has-ruff? ()
+    "Check if ruff exists in the current environment."
+    (has-exe? "ruff"))
+
+(defun has-ty? ()
+    "Check if ty exists in the current environment."
+    (has-exe? "ty"))
+
+(defun has-flycheck-ty? ()
+  "Non-nil if ty is registered in Flycheck."
+  (and (boundp 'flycheck-checkers)
+       (memq 'python-ty flycheck-checkers)))
+
+(defun my/flycheck-register-python-ty ()
+  "Define python-ty checker once."
+  (when (and (has-ty?) (not (has-flycheck-ty?)))
+    (flycheck-define-checker python-ty
+      "Python type checker using ty."
+      :command ("ty" "check" "--output-format" "concise"
+                (eval (or buffer-file-name default-directory)))
+      :error-patterns
+      ((error line-start (file-name) ":" line ":" column ": " (message) line-end))
+      :modes (python-mode python-ts-mode))
+
+    (add-to-list 'flycheck-checkers 'python-ty 'append)))
+
+(defun my/flycheck-set-python-chain (linter)
+  "Set LINTER as primary checker and chain to ty or mypy."
+  (setq-local flycheck-checker linter)
+
+  (when (fboundp 'flycheck-remove-next-checker)
+    (flycheck-remove-next-checker linter 'python-ty)
+    (flycheck-remove-next-checker linter 'python-mypy))
+
+  (cond
+   ((has-ty?)
+    (flycheck-add-next-checker linter 'python-ty))
+   ((has-mypy?)
+    (flycheck-add-next-checker linter 'python-mypy))))
+
+(defun my/flycheck-python-customizations ()
+  "Pick ruff/flake8 and chain to ty or mypy."
+  (my/flycheck-register-python-ty)
+
+  (cond
+   ((has-flake8?)
+    (my/flycheck-set-python-chain 'python-flake8))
+   ((has-ruff?)
+    (my/flycheck-set-python-chain 'python-ruff))
+   (t nil)))
+
+(use-package flycheck
+  :hook ((python-mode . my/flycheck-python-customizations)
+         (python-ts-mode . my/flycheck-python-customizations)))
+
+
+;;; setup-python-flycheck.el ends here

--- a/customizations/setup-python.el
+++ b/customizations/setup-python.el
@@ -30,7 +30,8 @@
   "Setup Python virtual environment."
   (interactive)
   (auto-virtualenv-setup)
-  (pyvenv-activate (auto-virtualenv-find-local-venv (auto-virtualenv-locate-project-root))))
+  (pyvenv-activate (auto-virtualenv-find-local-venv (auto-virtualenv-locate-project-root)))
+  (my/flycheck-python-customizations))
 
 (defun setup-elpy-command-hooks ()
   "Setup the rdd-py specific command hooks in elpy mode."
@@ -54,10 +55,6 @@
   (add-to-list 'company-backends 'company-jedi)
   (setq elpy-modules (delq 'elpy-module-flymake elpy-modules))
   :hook (elpy-mode . setup-elpy-command-hooks))
-
-(use-package flymake-ruff
-  :ensure t
-  :hook (python-mode . flymake-ruff-load))
 
 (use-package py-isort
   :ensure t)

--- a/init.el
+++ b/init.el
@@ -101,6 +101,7 @@
 (load "setup-python-rdd-jupyter.el")
 (load "setup-python-rdd-llm.el")
 (load "setup-python-rdd.el")
+(load "setup-python-flycheck.el")
 (load "setup-python.el")
 (load "setup-polymode.el")
 (load "setup-clojure.el")

--- a/init.el
+++ b/init.el
@@ -49,7 +49,6 @@
     exec-path-from-shell
     flycheck
     flycheck-clj-kondo
-    flymake-ruff
     gptel
     graphql-mode
     ido-completing-read+


### PR DESCRIPTION
Identify what tools are added in the local `.venv` of a Python project:

`ty` or `mypy`
`ruff` or `flake8`

Activate the _flyckeck_ checkers depending on what is in the current Python project.

possible combinations:
flake8 + mypy
flake8 + ty

ty + ruff
ty + mypy

![flycheck-setup-small](https://github.com/user-attachments/assets/6584991a-a3a4-481b-8995-30377b8c933a)
