### PR TITLE
use eglot and ty (for python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ On-the-fly syntax checking for GNU Emacs 24.
 ### flycheck-clj-kondo
 This package integrates clj-kondo with Emacs via flycheck. Make sure you also have clj-kondo installed globally on your machine according to the official install instructions.
 
+### flycheck-eglot
+A simple "glue" minor mode that allows Flycheck and Eglot to work together. Thus, the Flycheck frontend can display the results of syntactic checks performed by the LSP server.
+
 ### gptel
 GPTel is a simple Large Language Model chat client for Emacs, with support for multiple models/backends.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ c.InteractiveShellApp.extensions = ['autoreload']
 c.InteractiveShellApp.exec_lines = ['%autoreload 2']
 ```
 
+##### Python LSP
+I am evaluating `ty` as LSP server, using the built-in `eglot` to communicate with it.
+
+Ty need to be installed globally:
+``` shell
+uv tool install ty@latest
+
+# or
+pip install ty
+```
+
 ### Clojure
 Make sure you have `clj-kondo` installed on your machine according to the [install instructions](https://github.com/clj-kondo/clj-kondo/blob/master/doc/install.md)
 

--- a/customizations/editing.el
+++ b/customizations/editing.el
@@ -70,6 +70,28 @@
   :init (global-flycheck-mode)
   :hook (add-node-modules-path))
 
+(use-package flycheck-eglot
+  :ensure t
+  :after (flycheck eglot)
+  :custom (flycheck-eglot-exclusive nil)
+  :config
+  (global-flycheck-eglot-mode 1))
+
+(use-package eglot
+  :ensure t
+  :hook (python-mode . eglot-ensure)
+  :config
+  (add-to-list 'eglot-server-programs
+               '(python-mode . ("ty" "server")))
+  ;; Provide an empty workspace configuration for the "ty" section
+  ;; so that eglot can respond to workspace/configuration requests
+  (setq-default eglot-workspace-configuration '((:ty)))
+  ;; Customize keybindings for eglot to avoid conflicts with tools like elpy
+  (define-key eglot-mode-map (kbd "C-c r r") 'eglot-rename)
+  (define-key eglot-mode-map (kbd "C-c r e") 'eglot-code-actions)
+  (define-key eglot-mode-map (kbd "C-c r f") 'eglot-find-references)
+  (define-key eglot-mode-map (kbd "C-c r d") 'eglot-find-definition))
+
 (use-package company
   :ensure t
   :config

--- a/customizations/setup-python.el
+++ b/customizations/setup-python.el
@@ -68,22 +68,6 @@
               ("<f6>" . format-python-buffer-with-ruff)))
 
 
-;;; Eglot Configuration for Python
-(use-package eglot
-  :ensure t
-  :hook (python-mode . eglot-ensure)
-  :config
-  (add-to-list 'eglot-server-programs
-               '(python-mode . ("ty" "server")))
-  ;; Provide an empty workspace configuration for the "ty" section
-  ;; so that eglot can respond to workspace/configuration requests
-  (setq-default eglot-workspace-configuration '((:ty)))
-  ;; Customize keybindings for eglot to avoid conflicts with elpy
-  (define-key eglot-mode-map (kbd "C-c r r") 'eglot-rename)
-  (define-key eglot-mode-map (kbd "C-c r e") 'eglot-code-actions)
-  (define-key eglot-mode-map (kbd "C-c r f") 'eglot-find-references)
-  (define-key eglot-mode-map (kbd "C-c r d") 'eglot-find-definition))
-
 ;; Python shell buffer
 (setq display-buffer-alist
       '(((derived-mode . inferior-python-mode)

--- a/customizations/setup-python.el
+++ b/customizations/setup-python.el
@@ -52,8 +52,8 @@
   (setq elpy-formatter 'black)
   (setq elpy-shell-echo-input nil)
   (setq gud-pdb-command-name "python -m pdb")
-  (add-to-list 'company-backends 'company-jedi)
-  (setq elpy-modules (delq 'elpy-module-flymake elpy-modules))
+  ;; Disable elpy's Jedi and flymake to avoid conflicts with eglot
+  (setq elpy-modules (delq 'elpy-module-jedi (delq 'elpy-module-flymake elpy-modules)))
   :hook (elpy-mode . setup-elpy-command-hooks))
 
 (use-package py-isort
@@ -66,6 +66,16 @@
   :bind (:map python-mode-map
               ("<f5>" . format-python-buffer)
               ("<f6>" . format-python-buffer-with-ruff)))
+
+
+;;; Eglot Configuration for Python
+(use-package eglot
+  :ensure t
+  :hook (python-mode . eglot-ensure)
+  :config
+  (with-eval-after-load 'eglot
+    (add-to-list 'eglot-server-programs
+                 '(python-mode . ("ty" "lsp")))))
 
 ;; Python shell buffer
 (setq display-buffer-alist

--- a/customizations/setup-python.el
+++ b/customizations/setup-python.el
@@ -73,9 +73,16 @@
   :ensure t
   :hook (python-mode . eglot-ensure)
   :config
-  (with-eval-after-load 'eglot
-    (add-to-list 'eglot-server-programs
-                 '(python-mode . ("ty" "lsp")))))
+  (add-to-list 'eglot-server-programs
+               '(python-mode . ("ty" "server")))
+  ;; Provide an empty workspace configuration for the "ty" section
+  ;; so that eglot can respond to workspace/configuration requests
+  (setq-default eglot-workspace-configuration '((:ty)))
+  ;; Customize keybindings for eglot to avoid conflicts with elpy
+  (define-key eglot-mode-map (kbd "C-c r r") 'eglot-rename)
+  (define-key eglot-mode-map (kbd "C-c r e") 'eglot-code-actions)
+  (define-key eglot-mode-map (kbd "C-c r f") 'eglot-find-references)
+  (define-key eglot-mode-map (kbd "C-c r d") 'eglot-find-definition))
 
 ;; Python shell buffer
 (setq display-buffer-alist

--- a/init.el
+++ b/init.el
@@ -49,6 +49,7 @@
     exec-path-from-shell
     flycheck
     flycheck-clj-kondo
+    flycheck-eglot
     gptel
     graphql-mode
     ido-completing-read+


### PR DESCRIPTION
Using eglot and `ty` as LSP server for Python. Disabling some of the `elpy` features to avoid conflicts.